### PR TITLE
[#26] 녹음 버튼의 UI 및 상태로직 개선

### DIFF
--- a/apps/frontend/public/assets/images/record-button-disabled.svg
+++ b/apps/frontend/public/assets/images/record-button-disabled.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+  <circle cx="25" cy="25" r="20" fill="#CCCCCC" />
+  <circle cx="25" cy="25" r="10" fill="#FF9999" />
+</svg>

--- a/apps/frontend/public/assets/images/record-button.svg
+++ b/apps/frontend/public/assets/images/record-button.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+  <circle cx="25" cy="25" r="20" fill="#444444" />
+  <circle cx="25" cy="25" r="10" fill="#FF0000" />
+</svg>

--- a/apps/frontend/public/assets/images/recording-animation.svg
+++ b/apps/frontend/public/assets/images/recording-animation.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+  <circle cx="25" cy="25" r="20" fill="#444444" />
+  <circle cx="25" cy="25" r="10" fill="#FF0000">
+    <animate
+      attributeName="opacity"
+      values="1;0.3;1"
+      dur="1.5s"
+      repeatCount="indefinite"
+    />
+    <animate
+      attributeName="r"
+      values="10;12;10"
+      dur="1.5s"
+      repeatCount="indefinite"
+    />
+  </circle>
+</svg>

--- a/apps/frontend/src/app/chat/[name]/_components/RecordButton.module.css
+++ b/apps/frontend/src/app/chat/[name]/_components/RecordButton.module.css
@@ -6,10 +6,10 @@
   transform: scale(1.1);
 }
 
-.loading {
+.recording {
   cursor: not-allowed;
 }
 
-.fail {
+.disabled {
   cursor: not-allowed;
 }

--- a/apps/frontend/src/app/chat/[name]/_components/RecordButton.module.css
+++ b/apps/frontend/src/app/chat/[name]/_components/RecordButton.module.css
@@ -1,0 +1,15 @@
+.button {
+  cursor: pointer;
+}
+
+.button:hover {
+  transform: scale(1.1);
+}
+
+.loading {
+  cursor: not-allowed;
+}
+
+.fail {
+  cursor: not-allowed;
+}

--- a/apps/frontend/src/app/chat/[name]/_components/RecordButton.tsx
+++ b/apps/frontend/src/app/chat/[name]/_components/RecordButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, useCallback, useMemo } from "react";
 import { detectSilence } from "../_utils";
 import Image from "next/image";
 import styles from "./RecordButton.module.css";
@@ -12,33 +12,30 @@ import { selectCurrentRecordingAnswer } from "@/store/redux/features/chat/select
 import clsx from "clsx";
 
 export enum RecordingStatusType {
-  loading = "loading",
-  success = "success",
   idle = "idle",
-  fail = "fail",
+  recording = "recording",
+  finished = "finished",
 }
-
-const RECORD_BUTTON_ICON_SRC = {
-  [RecordingStatusType.idle]: "/assets/images/record-button.svg",
-  [RecordingStatusType.success]: "/assets/images/record-button.svg",
-  [RecordingStatusType.loading]: "/assets/images/recording-animation.svg",
-  [RecordingStatusType.fail]: "/assets/images/record-button-disabled.svg",
-};
 
 export default function RecordButton() {
   const recorderRef = useRef<Recorder | null>(null);
   const [recordingStatus, setRecordingStatus] = useState<RecordingStatusType>(
     RecordingStatusType.idle
   );
+  const [buttonIconSrc, setButtonIconSrc] = useState<string>(
+    "/assets/images/record-button.svg"
+  );
+
   const dispatch = useDispatch();
   const currentRecordingAnswer = useSelector(selectCurrentRecordingAnswer);
+  const isDisabledRecord =
+    currentRecordingAnswer?.status === ChatContentStatusType.fail;
 
   const handleRecord = async () => {
-    if (
-      recordingStatus === RecordingStatusType.loading ||
-      recordingStatus === RecordingStatusType.fail
-    )
-      return;
+    const isRecordingOrDisabled =
+      recordingStatus === RecordingStatusType.recording || isDisabledRecord;
+
+    if (isRecordingOrDisabled) return;
 
     const { mediaDevices } = navigator;
     const stream = await mediaDevices.getUserMedia({ audio: true });
@@ -53,9 +50,9 @@ export default function RecordButton() {
 
     await recorderRef.current.init(stream);
 
-    recorderRef.current
-      .start()
-      .then(() => setRecordingStatus(RecordingStatusType.loading));
+    recorderRef.current.start().then(() => {
+      setRecordingStatus(RecordingStatusType.recording);
+    });
 
     const source = audioContext.createMediaStreamSource(stream);
     source.connect(analyserNode);
@@ -89,53 +86,74 @@ export default function RecordButton() {
   };
 
   useEffect(() => {
-    if (recorderRef.current === null) return;
-    if (
-      recordingStatus === RecordingStatusType.idle ||
-      recordingStatus === RecordingStatusType.loading
-    )
-      return;
+    (function checkFinishedRecording() {
+      if (recorderRef.current === null) return;
 
-    if (recordingStatus === RecordingStatusType.success) {
-      finishRecord();
-    }
+      const isIdleRecordingOrDisabled =
+        recordingStatus === RecordingStatusType.idle || isDisabledRecord;
 
-    return () => {
-      setRecordingStatus(RecordingStatusType.idle);
-    };
+      if (isIdleRecordingOrDisabled) return;
+
+      const isFinishedRecording =
+        recordingStatus === RecordingStatusType.finished;
+
+      if (isFinishedRecording) {
+        finishRecord();
+      }
+    })();
   }, [recordingStatus]);
 
   useEffect(() => {
-    if (!currentRecordingAnswer) return;
+    (function checkAvailableRecordingIdle() {
+      if (!currentRecordingAnswer) return;
 
-    if (
-      currentRecordingAnswer?.status === ChatContentStatusType.success ||
-      currentRecordingAnswer?.status === ChatContentStatusType.idle
-    ) {
-      setRecordingStatus(RecordingStatusType.idle);
+      const isSuccessOrIdleRecording =
+        currentRecordingAnswer?.status === ChatContentStatusType.success ||
+        currentRecordingAnswer?.status === ChatContentStatusType.idle;
+
+      if (isSuccessOrIdleRecording) {
+        setRecordingStatus(RecordingStatusType.idle);
+      }
+    })();
+  }, [currentRecordingAnswer]);
+
+  useEffect(() => {
+    const IDLE_ICON_SRC = "/assets/images/record-button.svg";
+    const RECORDING_ICON_SRC = "/assets/images/recording-animation.svg";
+    const DISABLED_ICON_SRC = "/assets/images/record-button-disabled.svg";
+
+    const isRecording = recordingStatus === RecordingStatusType.recording;
+
+    if (isDisabledRecord) {
+      setButtonIconSrc(DISABLED_ICON_SRC);
+      return;
     }
 
-    if (currentRecordingAnswer?.status === ChatContentStatusType.fail) {
-      setRecordingStatus(RecordingStatusType.fail);
+    if (isRecording) {
+      setButtonIconSrc(RECORDING_ICON_SRC);
+      return;
     }
+
+    setButtonIconSrc(IDLE_ICON_SRC);
 
     return () => {
-      setRecordingStatus(RecordingStatusType.idle);
+      setButtonIconSrc(IDLE_ICON_SRC);
     };
-  }, [currentRecordingAnswer]);
+  }, [isDisabledRecord, recordingStatus]);
 
   return (
     <Image
+      data-testid="record-button"
       width={60}
       height={60}
-      src={RECORD_BUTTON_ICON_SRC[recordingStatus]}
+      src={buttonIconSrc}
       alt="record-button"
       sizes="60px"
       onClick={handleRecord}
       className={clsx([
         styles.button,
-        recordingStatus === RecordingStatusType.fail && styles.fail,
-        recordingStatus === RecordingStatusType.loading && styles.loading,
+        isDisabledRecord && styles.disabled,
+        recordingStatus === RecordingStatusType.recording && styles.recording,
       ])}
     />
   );

--- a/apps/frontend/src/app/chat/[name]/_utils/index.ts
+++ b/apps/frontend/src/app/chat/[name]/_utils/index.ts
@@ -46,7 +46,7 @@ export const detectSilence = (
     if (rms < silenceThreshold) {
       // 음성 중지 감지 (특정 시간 동안 rms가 임계값 이하인 경우)
       if (performance.now() - silenceStart > timeout) {
-        setIsRecording(RecordingStatusType.success);
+        setIsRecording(RecordingStatusType.finished);
         return;
       }
     } else {


### PR DESCRIPTION
# Summary

- 제목: 녹음 버튼의 UI 및 상태로직 개선

<br />

# Changes

- 녹음 버튼 아이콘 추가 및 변경
- 녹음 상태에 따른 버튼 결정 로직 수정
- 녹음 성공 실패가 아닌 녹음의 상태를 기준으로 수정

<br/>

# Screenshot

- 녹음 중 활성 상태로 UI 변화
<img src="https://github.com/user-attachments/assets/284d5fda-fa47-41eb-8c18-3fb88f920fda" width="400" />

- 응답 실패 시 비활성 상태로 UI 변화
<img src="https://github.com/user-attachments/assets/13b10f01-b28b-4edc-890b-435f9f1b4989" width="400" />

<br/>
