### PR TITLE
[#57] 서버 Result 라우트 구현 및 적용

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -45,10 +45,10 @@ model Interview {
   user          User                  @relation("UserInterviews", fields: [userId], references: [id])
   interviewerId Int
   interviewer   Interviewer           @relation("InterviewerInterviews", fields: [interviewerId], references: [id])
-  review        Review?               @relation("InterviewReview")
+  result        Result?               @relation("InterviewResult")
 }
 
- enum SpeakerRole {
+enum SpeakerRole {
   user
   interviewer
 }
@@ -63,7 +63,7 @@ model InterviewContent {
   interview     Interview             @relation("InterviewContents", fields: [interviewId], references: [id])
 }
 
-model Review {
+model Result {
   id                  Int                   @id @default(autoincrement())
   scores              Json      // 예: [{ "standard": "Technical", "score": 18, "summary": "좋음" }]
   contentFeedback     Json      // 각 문항에 대한 피드백
@@ -71,5 +71,5 @@ model Review {
   createdAt           DateTime              @default(now())
   updatedAt           DateTime              @updatedAt
   interviewId         Int                   @unique
-  interview           Interview             @relation("InterviewReview", fields: [interviewId], references: [id])
+  interview           Interview             @relation("InterviewResult", fields: [interviewId], references: [id])
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -8,7 +8,7 @@ import { authenticate } from '@/middleware/auth';
 import userRouter from '@/routes/user';
 import interviewerRouter from '@/routes/interviewer';
 import interviewRouter from '@/routes/interview';
-
+import resultRouter from '@/routes/result';
 const prisma = new PrismaClient();
 
 const app: Application = express();
@@ -30,6 +30,7 @@ app.get('/', (req, res) => {
 app.use('/user', userRouter);
 app.use('/interviewer', authenticate, interviewerRouter);
 app.use('/interview', authenticate, interviewRouter);
+app.use('/result', authenticate, resultRouter);
 
 const server = app.listen(config.server.port, () => {
   console.log(`http://${config.server.host}:${config.server.port} 실행`);

--- a/apps/backend/src/libs/constant.ts
+++ b/apps/backend/src/libs/constant.ts
@@ -30,6 +30,16 @@ export const INTERVIEW_ROUTE = {
   }
 };
 
+export const RESULT_ROUTE = {
+  error: {
+    notFoundInterview: '해당 인터뷰를 찾을 수 없습니다.',
+    failedToCreateResult: '결과 생성에 실패했습니다.',
+  },
+  message: {
+    alreadyExists: '이미 인터뷰 결과가 존재합니다.',
+  },
+};
+
 export const SERVER_ERROR = {
   internal: '서버에 문제가 발생했습니다.',
 };
@@ -38,4 +48,4 @@ export const VALIDATION_ERROR = {
   invalidInput: '입력값이 올바르지 않습니다.',
 };
 
-export const INTERVIEW_CHAT_LIMIT = 20;
+export const INTERVIEW_CHAT_LIMIT = 2;

--- a/apps/backend/src/libs/constant.ts
+++ b/apps/backend/src/libs/constant.ts
@@ -34,6 +34,7 @@ export const RESULT_ROUTE = {
   error: {
     notFoundInterview: '해당 인터뷰를 찾을 수 없습니다.',
     failedToCreateResult: '결과 생성에 실패했습니다.',
+    notFoundResult: '해당 결과를 찾을 수 없습니다.',
   },
   message: {
     alreadyExists: '이미 인터뷰 결과가 존재합니다.',

--- a/apps/backend/src/routes/result.ts
+++ b/apps/backend/src/routes/result.ts
@@ -1,0 +1,70 @@
+import { prisma } from '@/app';
+import { authenticate } from '@/middleware/auth';
+import { Router, Request, Response, NextFunction } from 'express';
+import { RESULT_ROUTE, VALIDATION_ERROR } from '@/libs/constant';
+import { generateEvaluation } from '@/libs/utils/prompt';
+
+const router: Router = Router();
+
+router.post('/', authenticate, async (req: Request, res: Response, next: NextFunction) => {
+  const { interviewId } = req.body;
+
+  if (!interviewId) {
+    res.status(400).json({ message: VALIDATION_ERROR.invalidInput });
+    return;
+  }
+
+  try {
+    const interview = await prisma.interview.findUnique({
+      where: {
+        id: interviewId,
+      },
+      select: {
+        id: true,
+        result: true,
+      },
+    });
+
+    if (!interview) {
+      res.status(404).json({ message: RESULT_ROUTE.error.notFoundInterview });
+      return;
+    }
+
+    if (interview?.result) {
+      res.status(409).json({ data: interview, message: RESULT_ROUTE.message.alreadyExists });
+      return;
+    }
+
+    const contents = await prisma.interviewContent.findMany({
+      where: {
+        interviewId,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+
+    const { success, scores, contentFeedback, feedback } = await generateEvaluation(contents);
+
+    if (!success) {
+      res.status(500).json({ message: RESULT_ROUTE.error.failedToCreateResult });
+      return;
+    }
+
+    const result = await prisma.result.create({
+      data: {
+        interviewId,
+        scores,
+        contentFeedback,
+        feedback,
+      },
+    });
+
+    res.status(201).json(result);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to create result' });
+  }
+});
+
+export default router;

--- a/apps/backend/src/routes/result.ts
+++ b/apps/backend/src/routes/result.ts
@@ -110,7 +110,18 @@ router.get('/:id', authenticate, async (req: Request, res: Response, next: NextF
       return;
     }
 
-    const response = GetResultResponseSchema.safeParse({ result });
+    const response = GetResultResponseSchema.safeParse({
+      id: result.id,
+      scores: result.scores,
+      contentFeedback: result.contentFeedback,
+      feedback: result.feedback,
+      interviewId: result.interviewId,
+      interview: result.interview,
+      userId: result.interview.userId,
+      user: result.interview.user,
+      interviewerId: result.interview.interviewerId,
+      interviewer: result.interview.interviewer,
+    });
 
     if (!response.success) {
       res.status(400).json({ message: VALIDATION_ERROR.invalidInput, errors: response.error.flatten().fieldErrors });

--- a/apps/backend/src/routes/result.ts
+++ b/apps/backend/src/routes/result.ts
@@ -39,7 +39,7 @@ router.post('/', authenticate, async (req: Request, res: Response, next: NextFun
     }
 
     if (interview?.result) {
-      res.status(409).json({ data: interview, message: RESULT_ROUTE.message.alreadyExists });
+      res.status(409).json({ id: interview.result.id, message: RESULT_ROUTE.message.alreadyExists });
       return;
     }
 

--- a/apps/backend/src/routes/result.ts
+++ b/apps/backend/src/routes/result.ts
@@ -67,4 +67,24 @@ router.post('/', authenticate, async (req: Request, res: Response, next: NextFun
   }
 });
 
+router.get('/:id', authenticate, async (req: Request, res: Response, next: NextFunction) => {
+  const { id: resultId } = req.params;
+
+  try {
+    const result = await prisma.result.findUnique({
+      where: { id: Number(resultId) },
+    });
+
+    if (!result) {
+      res.status(404).json({ message: RESULT_ROUTE.error.notFoundResult });
+      return;
+    }
+
+    res.status(200).json(result);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to get result' });
+  }
+});
+
 export default router;

--- a/apps/frontend/src/_apis/result.ts
+++ b/apps/frontend/src/_apis/result.ts
@@ -1,16 +1,18 @@
 import { z } from 'zod';
 import fetcher from './fetcher';
-import { GetResultRequestSchema, GetResultResponseSchema } from '@repo/schema/result';
+import {
+  CreateResultRequestSchema,
+  CreateResultResponseSchema,
+  GetResultRequestSchema,
+  GetResultResponseSchema,
+} from '@repo/schema/result';
 
 /**
  * 인터뷰 결과 생성
  */
-export interface CreateResultBody {
-  interviewId: number;
-}
-export interface CreateResultResponse {
-  id: number;
-}
+type CreateResultBody = z.infer<typeof CreateResultRequestSchema>;
+
+type CreateResultResponse = z.infer<typeof CreateResultResponseSchema>;
 
 export const fetchCreateResult = async ({ interviewId }: CreateResultBody) => {
   return fetcher.post<CreateResultResponse>('result', {

--- a/apps/frontend/src/_apis/result.ts
+++ b/apps/frontend/src/_apis/result.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod';
 import fetcher from './fetcher';
+import { GetResultRequestSchema, GetResultResponseSchema } from '@repo/schema/result';
 
 /**
  * 인터뷰 결과 생성
@@ -19,18 +21,12 @@ export const fetchCreateResult = async ({ interviewId }: CreateResultBody) => {
 /**
  * 인터뷰 결과 조회
  */
-export interface GetResultBody {
-  resultId: number;
-}
-export interface GetResultResponse {
-  id: number;
-  interviewId: number;
-  interviewerId: number;
-  userId: number;
-}
+type GetResultBody = z.infer<typeof GetResultRequestSchema>;
 
-export const fetchGetResult = async ({ resultId }: GetResultBody) => {
-  return fetcher.get<GetResultResponse>(`result/${resultId}`);
+type GetResultResponse = z.infer<typeof GetResultResponseSchema>;
+
+export const fetchGetResult = async ({ id }: GetResultBody) => {
+  return fetcher.get<GetResultResponse>(`result/${id}`);
 };
 
 /**

--- a/apps/frontend/src/_apis/result.ts
+++ b/apps/frontend/src/_apis/result.ts
@@ -15,9 +15,15 @@ type CreateResultBody = z.infer<typeof CreateResultRequestSchema>;
 type CreateResultResponse = z.infer<typeof CreateResultResponseSchema>;
 
 export const fetchCreateResult = async ({ interviewId }: CreateResultBody) => {
-  return fetcher.post<CreateResultResponse>('result', {
-    interviewId,
-  });
+  return fetcher.post<CreateResultResponse>(
+    'result',
+    {
+      interviewId,
+    },
+    {
+      timeout: 20000,
+    }
+  );
 };
 
 /**

--- a/apps/frontend/src/_apis/result.ts
+++ b/apps/frontend/src/_apis/result.ts
@@ -21,7 +21,7 @@ export const fetchCreateResult = async ({ interviewId }: CreateResultBody) => {
       interviewId,
     },
     {
-      timeout: 20000,
+      timeout: 50000,
     }
   );
 };

--- a/apps/frontend/src/_components/pages/interview/RecordButton/RecordButton.tsx
+++ b/apps/frontend/src/_components/pages/interview/RecordButton/RecordButton.tsx
@@ -260,7 +260,7 @@ export default function RecordButton() {
       return;
     }
 
-    mutate();
+    mutate(Number(interviewId));
   };
 
   if (interviewStatusLoading) {

--- a/apps/frontend/src/_components/pages/result/ButtonGroupSection.tsx
+++ b/apps/frontend/src/_components/pages/result/ButtonGroupSection.tsx
@@ -5,12 +5,14 @@ import styles from './ButtonGroupSection.module.css';
 import { useRouter, useParams } from 'next/navigation';
 import { useGetResult } from '@/_data/result';
 import { useCreateInterview } from '@/_data/interview';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface ButtonGroupSectionProps {}
 
 export default function ButtonGroupSection({}: ButtonGroupSectionProps): React.ReactElement {
   const router = useRouter();
   const resultId = useParams().resultId;
+  const queryClient = useQueryClient();
   const { data, isLoading, error } = useGetResult(Number(resultId));
   const { mutate, isPending } = useCreateInterview(
     data?.userId ?? 0,
@@ -24,10 +26,16 @@ export default function ButtonGroupSection({}: ButtonGroupSectionProps): React.R
     }
 
     mutate();
+
+    queryClient.invalidateQueries({ queryKey: ['result'] });
+    queryClient.invalidateQueries({ queryKey: ['interview'] });
   };
 
   const handleClickSelectInterviewer = () => {
     router.push('/interviewer');
+
+    queryClient.invalidateQueries({ queryKey: ['result'] });
+    queryClient.invalidateQueries({ queryKey: ['interview'] });
   };
 
   return (

--- a/apps/frontend/src/_components/pages/result/ButtonGroupSection.tsx
+++ b/apps/frontend/src/_components/pages/result/ButtonGroupSection.tsx
@@ -10,11 +10,19 @@ interface ButtonGroupSectionProps {}
 
 export default function ButtonGroupSection({}: ButtonGroupSectionProps): React.ReactElement {
   const router = useRouter();
-  const { data } = useGetResult();
-
-  const { mutate, isPending } = useCreateInterview(data?.userId!, data?.interviewerId!);
+  const resultId = useParams().resultId;
+  const { data, isLoading, error } = useGetResult(Number(resultId));
+  const { mutate, isPending } = useCreateInterview(
+    data?.userId ?? 0,
+    data?.interviewerId ?? 0,
+    data?.interview?.category ?? ''
+  );
 
   const handleClickRetryInterview = async () => {
+    if (error || isLoading) {
+      return;
+    }
+
     mutate();
   };
 

--- a/apps/frontend/src/_components/pages/result/QuestionEvaluationSection.tsx
+++ b/apps/frontend/src/_components/pages/result/QuestionEvaluationSection.tsx
@@ -1,17 +1,19 @@
 import Text from '@repo/ui/Text';
 import styles from './QuestionEvaluationSection.module.css';
-import { useGetResultQuestionEvaluation } from '@/_data/result';
+import { useGetResult } from '@/_data/result';
+import { useParams } from 'next/navigation';
 
 interface QuestionEvaluationSectionProps {}
 
 export default function QuestionEvaluationSection({}: QuestionEvaluationSectionProps): React.ReactElement {
-  const { data, isLoading, error } = useGetResultQuestionEvaluation();
+  const resultId = useParams().resultId;
+  const { data, isLoading, error } = useGetResult(Number(resultId));
 
   if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  if (!data || error) {
+  if (error) {
     return <div>no data</div>;
   }
 
@@ -20,17 +22,14 @@ export default function QuestionEvaluationSection({}: QuestionEvaluationSectionP
       <Text as="h3" size="md">
         Question Evaluation
       </Text>
-      {data?.questionEvaluation.map(({ title, score, content }, index) => (
-        <div className={styles.question}>
+      {data?.contentFeedback.map(({ question, feedback }, index) => (
+        <div className={styles.question} key={question}>
           <div className={styles.questionHeader}>
             <Text size="sm" weight="bold">
-              {index + 1}. {title}
-            </Text>
-            <Text size="sm" className={styles.questionScore}>
-              {score}%
+              {index + 1}. {question}
             </Text>
           </div>
-          <Text size="sm">{content}</Text>
+          <Text size="sm">{feedback}</Text>
         </div>
       ))}
     </div>

--- a/apps/frontend/src/_components/pages/result/ScoreSection.tsx
+++ b/apps/frontend/src/_components/pages/result/ScoreSection.tsx
@@ -1,12 +1,14 @@
 import Text from '@repo/ui/Text';
 import styles from './ScoreSection.module.css';
 import ProgressBar from './ProgressBar';
-import { useGetResultScore } from '@/_data/result';
+import { useGetResult } from '@/_data/result';
+import { useParams } from 'next/navigation';
 
 interface ScoreSectionProps {}
 
 export default function ScoreSection({}: ScoreSectionProps): React.ReactElement {
-  const { data, isLoading, error } = useGetResultScore();
+  const resultId = useParams().resultId;
+  const { data, isLoading, error } = useGetResult(Number(resultId));
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -16,6 +18,9 @@ export default function ScoreSection({}: ScoreSectionProps): React.ReactElement 
     return <div>no data</div>;
   }
 
+  const score = data?.scores.reduce((acc, curr) => acc + curr.score, 0) / data.scores.length;
+  const questionCount = data?.contentFeedback.length ?? 0;
+
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
@@ -24,7 +29,7 @@ export default function ScoreSection({}: ScoreSectionProps): React.ReactElement 
             Score
           </Text>
           <Text size="lg" align="right" weight="bold">
-            {data?.score}%
+            {score}%
           </Text>
         </div>
         <div className={styles.scoreWrapper}>
@@ -32,11 +37,11 @@ export default function ScoreSection({}: ScoreSectionProps): React.ReactElement 
             Question
           </Text>
           <Text size="lg" align="right" weight="bold">
-            {data?.questionCount}
+            {questionCount}
           </Text>
         </div>
       </div>
-      <ProgressBar score={data?.score ?? 0} duration={1500} />
+      <ProgressBar score={score} duration={1500} />
     </div>
   );
 }

--- a/apps/frontend/src/_components/pages/result/TotalEvaluationSection.tsx
+++ b/apps/frontend/src/_components/pages/result/TotalEvaluationSection.tsx
@@ -1,11 +1,12 @@
 import styles from './TotalEvaluationSection.module.css';
 import Text from '@repo/ui/Text';
-import { useGetResultTotalEvaluation } from '@/_data/result';
-
+import { useGetResult } from '@/_data/result';
+import { useParams } from 'next/navigation';
 interface TotalEvaluationSectionProps {}
 
 export default function TotalEvaluationSection({}: TotalEvaluationSectionProps): React.ReactElement {
-  const { data, isLoading, error } = useGetResultTotalEvaluation();
+  const resultId = useParams().resultId;
+  const { data, isLoading, error } = useGetResult(Number(resultId));
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -20,17 +21,17 @@ export default function TotalEvaluationSection({}: TotalEvaluationSectionProps):
       <Text as="h3" size="md">
         Total Evaluation
       </Text>
-      {data.evaluation.map(item => (
-        <div className={styles.evaluation}>
+      {data.scores.map(item => (
+        <div className={styles.evaluation} key={item.standard}>
           <div className={styles.evaluationHeader}>
             <Text size="sm" weight="bold">
-              {item.title}
+              {item.standard}
             </Text>
             <Text size="sm" className={styles.evaluationScore}>
               {item.score}%
             </Text>
           </div>
-          <Text size="sm">{item.content}</Text>
+          <Text size="sm">{item.summary}</Text>
         </div>
       ))}
     </div>

--- a/apps/frontend/src/_data/result.ts
+++ b/apps/frontend/src/_data/result.ts
@@ -45,12 +45,10 @@ export const useCreateResult = () => {
   });
 };
 
-export const useGetResult = () => {
-  const resultId = useParams().resultId;
-
+export const useGetResult = (resultId: number) => {
   return useQuery({
     queryKey: ['result', resultId],
-    queryFn: () => fetchGetResult({ id: Number(resultId) }),
+    queryFn: () => fetchGetResult({ id: resultId }),
   });
 };
 

--- a/apps/frontend/src/_data/result.ts
+++ b/apps/frontend/src/_data/result.ts
@@ -9,34 +9,27 @@ import {
 import { useRouter, useParams } from 'next/navigation';
 import useToastStore from '@repo/store/useToastStore';
 import { APIError } from '@/_apis/fetcher';
-import { delay } from '@/_libs/utils';
 
 export const useCreateResult = () => {
   const router = useRouter();
-  const interviewId = useParams().interviewId;
   const addToast = useToastStore(state => state.addToast);
 
   return useMutation({
-    mutationFn: async () => {
-      await delay(500);
-
+    mutationFn: async (interviewId: number) => {
       return await fetchCreateResult({
-        interviewId: Number(interviewId),
+        interviewId,
       });
     },
     onSuccess: data => {
-      if (!data?.id) {
-        addToast({
-          title: '인터뷰 결과 생성 실패',
-          description: '인터뷰 결과 생성에 실패했습니다. 다시 시도해주세요.',
-        });
-        return;
-      }
-
       router.push(`/result/${data.id}`);
     },
     onError: error => {
       if (error instanceof APIError) {
+        if (error.status === 409) {
+          router.push(`/result/${(error.data as { id: number }).id}`);
+          return;
+        }
+
         addToast({
           title: '인터뷰 결과 생성 실패',
           description: error.message,

--- a/apps/frontend/src/_data/result.ts
+++ b/apps/frontend/src/_data/result.ts
@@ -50,7 +50,7 @@ export const useGetResult = () => {
 
   return useQuery({
     queryKey: ['result', resultId],
-    queryFn: () => fetchGetResult({ resultId: Number(resultId) }),
+    queryFn: () => fetchGetResult({ id: Number(resultId) }),
   });
 };
 

--- a/apps/frontend/src/app/result/[resultId]/page.tsx
+++ b/apps/frontend/src/app/result/[resultId]/page.tsx
@@ -1,25 +1,26 @@
 'use client';
 
 import styles from './page.module.css';
-
 import Text from '@repo/ui/Text';
 import ScoreSection from '@/_components/pages/result/ScoreSection';
 import TotalEvaluationSection from '@/_components/pages/result/TotalEvaluationSection';
 import QuestionEvaluationSection from '@/_components/pages/result/QuestionEvaluationSection';
 import ButtonGroupSection from '@/_components/pages/result/ButtonGroupSection';
 import { useGetResult } from '@/_data/result';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import { APIError } from '@/_apis/fetcher';
 
 export default function Page() {
   const router = useRouter();
-  const { data, isLoading, error } = useGetResult();
+  const resultId = useParams().resultId;
+
+  const { isLoading, error } = useGetResult(Number(resultId));
 
   if (isLoading) {
     return <div>Loading...</div>;
   }
 
-  if (error) {
+  if (!resultId || error) {
     throw new APIError('인터뷰 결과 조회에 실패했습니다. 다시 시도해주세요.', 404, 'NOT_FOUND', error, () => {
       router.replace('/interviewer');
     });

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/interview.js",
       "require": "./dist/interview.cjs",
       "types": "./dist/interview.d.ts"
+    },
+    "./result": {
+      "import": "./dist/result.js",
+      "require": "./dist/result.cjs",
+      "types": "./dist/result.d.ts"
     }
   },
   "dependencies": {

--- a/packages/schema/src/result.ts
+++ b/packages/schema/src/result.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { InterviewerSchema } from './interviewer';
+import { UserSchema } from './user';
+
+/**
+ * 모델 및 타입
+ */
+export const ResultScoresSchema = z.array(
+  z.object({
+    standard: z.string(),
+    score: z.number(),
+    summary: z.string(),
+  })
+);
+
+export const ResultContentsFeedbackSchema = z.array(
+  z.object({
+    question: z.string(),
+    feedback: z.string(),
+  })
+);
+
+export const ResultFeedbackSchema = z.string();
+
+/**
+ * 요청 및 응답
+ */
+export const CreateResultRequestSchema = z.object({
+  interviewId: z.number(),
+});
+
+export const CreateResultResponseSchema = z.object({
+  id: z.number(),
+  interviewId: z.number(),
+  interviewerId: z.number(),
+});
+
+export const GetResultRequestSchema = z.object({
+  id: z.number(),
+});
+
+export const GetResultResponseSchema = z.object({
+  id: z.number(),
+  interviewId: z.number(),
+  interviewerId: z.number(),
+  interviewer: InterviewerSchema,
+  userId: z.number(),
+  user: UserSchema,
+  contentFeedback: ResultContentsFeedbackSchema,
+  feedback: ResultFeedbackSchema,
+  scores: ResultScoresSchema,
+});

--- a/packages/schema/src/result.ts
+++ b/packages/schema/src/result.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { InterviewSchema } from './interview';
 import { InterviewerSchema } from './interviewer';
 import { UserSchema } from './user';
 
@@ -31,8 +32,6 @@ export const CreateResultRequestSchema = z.object({
 
 export const CreateResultResponseSchema = z.object({
   id: z.number(),
-  interviewId: z.number(),
-  interviewerId: z.number(),
 });
 
 export const GetResultRequestSchema = z.object({
@@ -42,6 +41,7 @@ export const GetResultRequestSchema = z.object({
 export const GetResultResponseSchema = z.object({
   id: z.number(),
   interviewId: z.number(),
+  interview: InterviewSchema,
   interviewerId: z.number(),
   interviewer: InterviewerSchema,
   userId: z.number(),

--- a/packages/schema/tsup.config.ts
+++ b/packages/schema/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/user.ts', 'src/interviewer.ts', 'src/interview.ts'],
+  entry: ['src/index.ts', 'src/user.ts', 'src/interviewer.ts', 'src/interview.ts', 'src/result.ts'],
   outDir: 'dist',
   format: ['esm', 'cjs'],
   dts: true,


### PR DESCRIPTION
# Summary

- 제목: 서버 Result 라우트 구현 및 적용

  <br />

# Changes

- [x] 인터뷰 결과 데이터 생성 라우트 구현
- [x] 인터뷰 결과 생성 요청 스키마 및 api 구현
- [x] 인터뷰 결과 데이터 조회 라우트 구현
- [x] 인터뷰 결과, 평가에 대한 프롬프트 구현
- [x] 인터뷰 결과 생성 및 조회 클라이언트에 반영

<br/>
